### PR TITLE
.buffer-newmessage => .buffer-newevent. newmessage is for msg.type 1&4

### DIFF
--- a/public/javascripts/views.js
+++ b/public/javascripts/views.js
@@ -230,9 +230,12 @@ Views.addBuffer = function(networkname, buffer) {
 };
 
 Views.bufferHighlight = function(bufferId, message) {
-	$(".channel[data-buffer-id="+bufferId+"]").addClass("buffer-newmessage");
+	$(".channel[data-buffer-id="+bufferId+"]").addClass("buffer-newevent");
 	if (typeof message !== "undefined") {
 		reviver.afterReviving(message, function(obj) {
+			if (obj.type == MT.Plain || obj.type == MT.Action) {
+				$(".channel[data-buffer-id="+bufferId+"]").addClass("buffer-newmessage");
+			}
 			if (obj.isHighlighted()) {
 				$(".channel[data-buffer-id="+bufferId+"]").addClass("buffer-highlight");
 			}
@@ -241,7 +244,7 @@ Views.bufferHighlight = function(bufferId, message) {
 };
 
 Views.bufferMarkAsRead = function(bufferId) {
-	$(".channel[data-buffer-id="+bufferId+"]").removeClass("buffer-newmessage buffer-highlight");
+	$(".channel[data-buffer-id="+bufferId+"]").removeClass("buffer-newevent buffer-newmessage buffer-highlight");
 };
 
 Views.setStatusBuffer = function(networkname, buffer) {


### PR DESCRIPTION
Rename the class that is added on a buffer event from `.buffer-newmessage` to `.buffer-newevent`.
If the buffer event is a Message.Type.Plain=1 or Action=4, the `.buffer-newmessage` class is also added.

I did not style `.buffer-newevent` as I personally think it's pointless.
