### PR TITLE
List settings.theme in theme selector if not a packaged theme.

### DIFF
--- a/public/javascripts/angular-controller.js
+++ b/public/javascripts/angular-controller.js
@@ -257,39 +257,21 @@ angular.module('quassel')
     };
 })
 .controller('ConfigController', ['$scope', '$modal', '$theme', function($scope, $modal, $theme) {
-    $scope.theme = "";
-    $scope.themes = $theme.get();
-    
-    $scope.$watch('theme', function(newValue, oldValue) {
-        if (newValue) {
-            $scope.themes.forEach(function(element){
-                element.active = (element.name === $scope.theme);
-            });
-            $theme.save($scope.themes);
-        }
-    });
-    
+    // $scope.activeTheme is assigned in the theme directive
+    $scope.getAllThemes = $theme.getAllThemes;
+    $scope.setTheme = function(theme) {
+        $scope.activeTheme = theme;
+        $theme.setClientTheme(theme);
+    }
+
     $scope.configTheme = function() {
         $modal.open({
             templateUrl: 'modalChangeTheme.html',
-            controller: 'ModalChangeThemeInstanceCtrl',
-            resolve: {
-                ctrlScope: function(){return $scope;}
-            }
+            scope: $scope,
         });
-    };
+    };   
+    
 }])
-.controller('ModalChangeThemeInstanceCtrl', function ($scope, $modalInstance, ctrlScope) {
-    $scope.themes = ctrlScope.themes;
-    
-    $scope.ok = function () {
-        $modalInstance.close();
-    };
-    
-    $scope.setTheme = function (theme) {
-        ctrlScope.theme = theme.name;
-    };
-})
 .controller('SocketController', ['$scope', '$socket', '$er', '$timeout', '$window', '$alert', function($scope, $socket, $er, $timeout, $window, $alert) {
     $scope.disconnected = false;
     $scope.connecting = false;

--- a/public/javascripts/angular-directive.js
+++ b/public/javascripts/angular-directive.js
@@ -14,18 +14,14 @@ angular.module('quassel')
     var regex = /(.*theme-).*\.css$/;
     
     return {
-        scope: {
-            theme: "=",
-        },
         require: '?defaultTheme',
         link: function (scope, element, attrs) {
-            if ($theme.default()) {
-                $parse(attrs.theme).assign(scope, $theme.default());
-            } else {
-                $parse(attrs.theme).assign(scope, attrs.defaultTheme);
+            $theme.setDefaultTheme(attrs.defaultTheme);
+            if ($theme.getClientTheme()) {
+                scope.activeTheme = $theme.getClientTheme();
             }
             
-            scope.$watch('theme', function(newValue, oldValue){
+            scope.$watch('activeTheme', function(newValue, oldValue){
                 if (newValue) {
                     var href = element.attr("href");
                     href = href.replace(regex, "$1" + newValue + ".css");

--- a/public/javascripts/angular-init.js
+++ b/public/javascripts/angular-init.js
@@ -114,40 +114,29 @@ angular.module('quassel', ['ngSocket', 'ngSanitize', 'er', 'ui.bootstrap', 'drag
     };
 }])
 .factory('$theme', [function(){
-    var obj = [{
-        name: 'default',
-        active: true
-    },{
-        name: 'darksolarized',
-        active: false
-    }];
-    
-    load();
-    
-    function save(newobj) {
-        newobj.forEach(function(element){
-            if (element.active) localStorage.defaultTheme = element.name;
-        });
-    }
-    
-    function load() {
-        if (localStorage.defaultTheme) {
-            obj.forEach(function(element){
-                if (element.name === localStorage.defaultTheme) element.active = true;
-                else element.active = false;
-            });
-        }
-    }
-    
+    var defaultTheme = '';
+    var packagedThemes = [
+        'default',
+        'darksolarized',
+    ];
+
     return {
-        get: function() {
-            return obj;
+        setDefaultTheme: function(theme) {
+            defaultTheme = theme;
         },
-        default: function() {
-            return localStorage.defaultTheme?localStorage.defaultTheme:null;
+        getClientTheme: function() {
+            return localStorage.defaultTheme || null;
         },
-        save: save,
-        load: load
+        setClientTheme: function(theme) {
+            localStorage.defaultTheme = theme;
+        },
+        getAllThemes: function() {
+            var themes = [].concat(packagedThemes);
+            if (defaultTheme && themes.indexOf(defaultTheme) === -1) {
+                themes.push(defaultTheme);
+            }
+            return themes;
+        },
     };
 }])
 .factory('$wfocus', [function(){

--- a/views/index.jade
+++ b/views/index.jade
@@ -10,7 +10,7 @@ html(ng-app="quassel", ng-controller="ConfigController")
       link(rel='icon', href='favicon.ico')
       link(rel='stylesheet', href='#{settings.prefixpath}/stylesheets/bootstrap.min.css')
       link(rel='stylesheet', href='#{settings.prefixpath}/stylesheets/fonts.css')
-      link(rel='stylesheet', href='#{settings.prefixpath}/stylesheets/theme-#{settings.theme}.css', default-theme="#{settings.theme}", theme="theme")
+      link(rel='stylesheet', href='#{settings.prefixpath}/stylesheets/theme-#{settings.theme}.css', default-theme="#{settings.theme}", theme)
       
     body.login-page
       script(type="text/ng-template", id="modalJoinChannel.html")
@@ -27,13 +27,11 @@ html(ng-app="quassel", ng-controller="ConfigController")
           button.btn.btn-default(type='button', ng-click='ok()') Join channel
       script(type="text/ng-template", id="modalChangeTheme.html")
         .modal-header
-          button.close(type='button', data-dismiss='modal', aria-hidden='true') ×
+          button.close(type='button', ng-click='$dismiss("close")') ×
           h4#myModalLabel.modal-title Select theme
         .modal-body
           .list-group
-            a.list-group-item(href="#", ng-repeat="theme in themes", ng-class="{active: theme.active}", ng-click="setTheme(theme)") {{theme.name}}
-        .modal-footer
-          button.btn.btn-default(type='button', ng-click='ok()') Close
+            a.list-group-item(href="#", ng-repeat="theme in getAllThemes()", ng-class="{active: activeTheme == theme}", ng-click="setTheme(theme)") {{theme}}
       #container(ng-controller="SocketController", ng-class="{connecting: connecting, disconnected: disconnected}")
         #header.dropdown(dropdown)
           span.quassel-logo


### PR DESCRIPTION
Hold off on merging this as I might change something which I thought of while writing this blurb. Going to review it tomorrow.

I sort of refactored some of theme management code, which wasn't necessary but I wanted to distinguish between the server's `defaultTheme` set in the `settings.js` and the client's `localStorage.defaultTheme`. I origionally was just going to add a `, { name: 'user', active: false }` into the `obj` list with `theme-user.less` in the gitignore. However, I needed to detect if that file existed somehow before listing it in the UI.

I passed the ConfigController scope into the changeThemeModal as `scope` instead of `ctrlScope` so it could easily access it's parent scope data. **I might undo this change** as 
[angular-ui modals](https://angular-ui.github.io/bootstrap/#/modal) inject `$dismiss()` and `$close` functions into their scope.

This also fixes the X button on changeThemeModal and remove the close button in the footer which duplicates it's function. The X button in the JoinBufferModal still needs to be fixed.