### PR TITLE
add reverse proxy snippet for Apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ location /quassel {
     proxy_redirect off;
 }
 ```
+#### Apache
+Needs activated mod_proxy_wstunnel and mod_rewrite
+```
+RewriteEngine on
+RewriteRule /quassel/p/socket(.*) ws://127.0.0.1:64080/quassel/p/socket$1 [P,L]
+ProxyPass /quassel http://127.0.0.1:64080/quassel
+```
 
 ## License
 Copyright (c) 2014-2015 Joël Charles  


### PR DESCRIPTION
fixes #76

using RewriteRule because ws:// isn't working correctly with ProxyPass
"right" way according to apache manual:
ProxyPass /quassel/p/socket ws://127.0.0.1:64080/quassel/p/socket