### PR TITLE
Update README with note on --listen localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ In you run behind `/quassel` location on your webserver, do not forget to edit `
 prefixpath: '/quassel',
 ...
 ```
-Also, be sure to launch quassel-webserver in http mode by adding `-m http` to the command line.
+Also, be sure to launch quassel-webserver in http mode by adding `-m http` to the command line, optionally including `-l localhost` to block direct outside connections from bypassing the proxy server.
 #### nginx
 ```nginx
 # rewrite ^[/]quassel$ /quassel/ permanent;


### PR DESCRIPTION
## In brief

* Add recommendation to specify ```-l localhost``` when setting up a reverse proxy
 * Blocks direct outside connections that bypass the proxy
 * Mimics how other reverse-proxy systems are set up, such as PHP

*As this is a trivial documentation-only change, I've skipped the usual breakdown and analysis.  Only risk should be inaccurate comments.*