### PR TITLE
Add the packaging metadata to build the quassel-webserver snap

### DIFF
--- a/app.js
+++ b/app.js
@@ -104,7 +104,13 @@ app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
 app.use(cookieParser());
-app.use(settings.prefixpath, lessMiddleware(path.join(__dirname, 'public')));
+if (process.env.SNAP_DATA) {
+    app.use(settings.prefixpath, lessMiddleware(path.join(__dirname, 'public'), {
+        dest: path.join(process.env.SNAP_DATA)
+    }));
+} else {
+    app.use(settings.prefixpath, lessMiddleware(path.join(__dirname, 'public')));
+}
 app.get(settings.prefixpath+'/javascripts/libquassel.js', function(req, res) {
     res.sendFile(path.join(__dirname, 'node_modules/libquassel/client/libquassel.js'));
 });

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,6 +11,7 @@ apps:
   server:
     command: node $SNAP/lib/node_modules/quassel-webserver/app.js
     plugs: [network, network-bind]
+    daemo: simple
 
 parts:
   quassel-webserver:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,7 +11,7 @@ apps:
   server:
     command: node $SNAP/lib/node_modules/quassel-webserver/app.js
     plugs: [network, network-bind]
-    daemo: simple
+    daemon: simple
 
 parts:
   quassel-webserver:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: quassel-webserver
+version: master
+summary: A web server/client for Quassel
+description: |
+  A web client for Quassel (requires a running quasselcore)
+
+grade: devel
+confinement: strict
+
+apps:
+  server:
+    command: node $SNAP/lib/node_modules/quassel-webserver/app.js
+    plugs: [network, network-bind]
+
+parts:
+  quassel-webserver:
+    source: .
+    plugin: nodejs


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds for adventurous users.
