### PR TITLE
fix socket and listen in settings.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
 var lessMiddleware = require('less-middleware');
 var fs = require('fs');
+var untildify = require('untildify');
 var pjson = require('./package.json');
 var opts = require('commander');
 var netBrowserify = require('net-browserify-alt');
@@ -25,10 +26,10 @@ var routes = require('./routes/index');
 
 if (settings.val.webserver) {
     if (settings.val.webserver.socket && !opts.socket) {
-        opts.socket === settings.val.webserver.socket;
+        opts.socket = untildify(settings.val.webserver.socket);
     }
     if (settings.val.webserver.listen && !opts.listen) {
-        opts.listen === settings.val.webserver.listen;
+        opts.listen = settings.val.webserver.listen;
     }
     if (settings.val.webserver.port && !opts.port) {
         opts.port = settings.val.webserver.port;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "morgan": "^1.8.0",
     "net-browserify-alt": "^1.1.0",
     "pug": "^2.0.0-beta11",
-    "serve-favicon": "~2.3.2"
+    "serve-favicon": "~2.3.2",
+    "untildify": "^3.0.2"
   },
   "optionalDependencies": {
     "httpolyglot": "~0.1.2"


### PR DESCRIPTION
For some reason these values were assigned with === instead of =, using
= works.

Also use untildify on the socket path to allow tilde expansion in socket
paths from settings.js .