### PR TITLE
Properly force default

### DIFF
--- a/app.js
+++ b/app.js
@@ -167,7 +167,7 @@ if (app.get('env') === 'development') {
     });
 }
 
-ws(server);
+ws(server, settings);
 
 if (app.get('socket')) {
     var socket = app.get('socket');

--- a/ws.js
+++ b/ws.js
@@ -17,7 +17,7 @@ function createSocket(host, port, callback) {
     return socket;
 }
 
-module.exports = function(server) {
+module.exports = function(server, settings) {
     const wss = new WebSocket.Server({
         server: server
     });
@@ -25,7 +25,12 @@ module.exports = function(server) {
     wss.on('connection', function connection(ws, req) {
         ws.once('message', function incoming(targetInfo) {
             // First message is the information about the target server
-            const { server, port } = JSON.parse(targetInfo);
+            var { server, port } = JSON.parse(targetInfo);
+            
+            if (settings.forcedefault) {
+                server = settings.default.host;
+                port = settings.default.port;
+            }
             
             const socket = createSocket(server, port, (err) => {
                 if (err) return ws.send(err);

--- a/ws.js
+++ b/ws.js
@@ -27,13 +27,13 @@ module.exports = function(server, settings) {
             // First message is the information about the target server
             var { server, port } = JSON.parse(targetInfo);
             
-            if (settings.forcedefault) {
-                server = settings.default.host;
-                port = settings.default.port;
+            if (settings.val.forcedefault) {
+                server = settings.val.default.host;
+                port = settings.val.default.port;
             }
             
             const socket = createSocket(server, port, (err) => {
-                if (err) return ws.send(err);
+                if (err) return ws.send(err.toString());
             });
             
             ws.on('message', function (data) {


### PR DESCRIPTION
Currently, if the client supplies a different host from the one in the settings, the server will accept it anyway and attempt to connect. Maybe this is intended behaviour, but my understanding of "Will force default host and port to be used if true" is that there will be validations server-side to ensure this is true. This PR adds those server-side checks :)

Also, this PR fixes a bug that crashes the server when an error is encountered when connecting to the quassel core. Now instead, the client gets messed up.

Please squash and merge this PR since I made most of them on GitHub and could only edit one file at a time.