### PR TITLE
settings: Fix ignoring 'securecore: false' default

### DIFF
--- a/public/javascripts/angular-init.js
+++ b/public/javascripts/angular-init.js
@@ -157,7 +157,7 @@ angular.module('quassel', ['ngQuassel', 'ngAria', 'ngSanitize', 'ui.bootstrap', 
             set('port', data.settings.port);
             set('initialBacklogLimit', data.settings.initialBacklogLimit);
             set('backlogLimit', data.settings.backlogLimit);
-            set('securecore', data.settings.securecore || true);
+            set('securecore', (typeof data.settings.securecore === 'boolean' ? data.settings.securecore : true));
             set('theme', data.settings.theme);
             set('perchathistory', data.settings.perchathistory);
             set('displayfullhostmask', data.settings.displayfullhostmask);


### PR DESCRIPTION
## In brief

* Don't use `||` to set default for `securecore`, instead check `typeof`
  * Otherwise, `false` evaluates to `false` and `securecore` can never be defaulted to `false`
  * Fixes ignoring custom default setting `securecore: false` in `settings-user.json`
  * Eases working around [SSL/TLS connection failure issue #285 in Ubuntu 20.04](https://github.com/magne4000/quassel-webserver/issues/285 )

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Fixes non-default configuration of uncommon setting
Risk | ★☆☆ *1/3* | `securecore` value might not be set correctly
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Testing

### Steps

1.  Set `securecore: <value>` in `settings-user.json`
    * Or, comment out the value like `// securecore: value`
2.  Restart/reload Quassel Webserver as needed to apply the new value
    * Verify with `<URL to Quassel Webserver>/settings`, e.g. `http://localhost/chat/settings`
3.  Open a fresh Private Browsing/Incognito tab
4.  Navigate to the Quassel Webserver instance
5.  Verify `Local settings replaced by default settings (new version)` is shown
6.  Expand `more options`
7.  Observe the checked state of the `SSL core connection` checkbox

### Before

* `SSL core connection` checkbox is always checked, ignoring the value of `securecore`

### After

* :checkered_flag: `SSL core connection` checkbox is checked when `securecore: true` or when `securecore` is entirely commented out
* :new: `SSL core connection` checkbox is unchecked when `securecore: false`